### PR TITLE
Fix Failed to execute 'fetch' on 'WorkerGlobalScope': Request with GET/HEAD method cannot have body

### DIFF
--- a/ptp-add-filter-all-releases-anut.js
+++ b/ptp-add-filter-all-releases-anut.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         PTP - Add releases from other trackers
 // @namespace    https://github.com/Audionut/add-trackers
-// @version      4.6.1-A
+// @version      4.6.0-A
 // @description  Add releases from other trackers
 // @author       passthepopcorn_cc (edited by Perilune + Audionut)
 // @match        https://passthepopcorn.me/torrents.php?id=*

--- a/ptp-add-filter-all-releases-anut.js
+++ b/ptp-add-filter-all-releases-anut.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         PTP - Add releases from other trackers
 // @namespace    https://github.com/Audionut/add-trackers
-// @version      4.6.0-A
+// @version      4.6.1-A
 // @description  Add releases from other trackers
 // @author       passthepopcorn_cc (edited by Perilune + Audionut)
 // @match        https://passthepopcorn.me/torrents.php?id=*
@@ -1975,7 +1975,7 @@ function toUnixTime(dateString) {
                 GM_xmlhttpRequest({
                     url: post_query_url,
                     method: method,
-                    data: (tracker === 'YUS' || tracker === 'OTW' || tracker === 'HHD') ? new URLSearchParams(postData).toString() : JSON.stringify(postData),
+                    data: (tracker === 'YUS' || tracker === 'OTW' || tracker === 'HHD' || tracker === 'FL') ? new URLSearchParams(postData).toString() : JSON.stringify(postData),
                     headers: headers,
                     onload: (res) => {
                         clearTimeout(timer);


### PR DESCRIPTION
Fix the below error for FL tracker 

`statusText : "Failed to execute 'fetch' on 'WorkerGlobalScope': Request with GET/HEAD method cannot have body."`

<img width="1594" height="2354" alt="image" src="https://github.com/user-attachments/assets/82c1a414-4315-4ecf-a55e-0c0de2bbba67" />
